### PR TITLE
fixed the css grid for register and login pages

### DIFF
--- a/src/style/register.css
+++ b/src/style/register.css
@@ -1,7 +1,7 @@
 .register {  
 	display: grid;
 	grid-template-columns: 1fr 3fr 1fr;
-	grid-template-rows: 1fr 4fr;
+	grid-template-rows: 1fr 7fr;
 	grid-template-areas:
 			"header header header"
 			". main ."


### PR DESCRIPTION
Edited the register.css file (line 4) . Since we are fr (fractional relative unit), the grid-template-row size need to be 1fr 7fr since the size of the register form is much larger than the login form. using fr units is important because it'll make our website responsive!